### PR TITLE
Dependabot/maven/org.springframework spring web 6.0.0, Add Oracle Maven repository and comments 

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ Multi Queuing Mail using AQ, JMS and so on..
 see in detail below..
 
 ## SDK
-JDK 1.8
+JDK 11+
 
 ## Framework
-Spring 4x
+Spring 5x
 
 Apache Thrift
 
@@ -16,7 +16,9 @@ JMX
 
 JMS
 
-Oracle AQ
+Activemq
+
+Oracle AQ (Deprecated, but to be manually installed in $ORACLE_HOME/rdbms/jlib/aqapi.jar)
 
 Thymeleaf
 
@@ -30,7 +32,7 @@ sendmail..
 $>java -Dfile.encoding=UTF-8 -classpath ...jar org.mail.client.CliMain -i 2000
 
 ## Queue
-CASE 1. Oracle Streams Advanced Queuing
+CASE 1. Oracle Streams Advanced Queuing (Deprecated, but to be manually installed in $ORACLE_HOME/rdbms/jlib/aqapi.jar)
 
 Procedure (PL/SQL):
 ```
@@ -38,7 +40,7 @@ CREATE OR REPLACE TYPE USER_DEFINED_TYPE AS OBJECT (
     global_user_id NUMBER(7),
     mail_info_type NUMBER(2),
     datetime TIMESTAMP
-);  
+);
 /
 BEGIN DBMS_AQADM.CREATE_QUEUE_TABLE(
     Queue_table        => 'QUEUE_TABLE',
@@ -53,12 +55,12 @@ BEGIN DBMS_AQADM.CREATE_QUEUE(
     Queue_table         => 'QUEUE_TABLE',
     Queue_type          =>  0,
     Max_retries         =>  5,
-    Retry_delay         =>  0,     
+    Retry_delay         =>  0,
     dependency_tracking =>  FALSE);
 END;
 /
 BEGIN
-	dbms_aqadm.start_queue (queue_name => 'QUEUE', enqueue => TRUE , dequeue => TRUE); 
+	dbms_aqadm.start_queue (queue_name => 'QUEUE', enqueue => TRUE , dequeue => TRUE);
 END;
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -147,6 +147,17 @@
             <artifactId>activemq-client</artifactId>
             <version>5.15.14</version>
         </dependency>
-
     </dependencies>
+
+    <repositories>
+        <repository>
+            <id>maven.oracle.com</id>
+            <url>https://maven.oracle.com</url>
+            <layout>default</layout>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+        </repository>
+    </repositories>
 </project>
+

--- a/src/main/java/org/mail/db/OracleAqFactoryBean.java
+++ b/src/main/java/org/mail/db/OracleAqFactoryBean.java
@@ -26,7 +26,7 @@ public class OracleAqFactoryBean implements FactoryBean {
 
     @Override
     public Object getObject() throws Exception {
-        // NOTE: if you don't use to session Message Listener for oracle aq, delete me
+        // NOTE: if use to session Message Listener for oracle aq, uncomment this code
         // return AQjmsFactory.getQueueConnectionFactory(defaultDataSource);
         return new ActiveMQConnectionFactory(brokerUrl);
     }

--- a/src/main/java/org/mail/db/OracleAqFactoryBean.java
+++ b/src/main/java/org/mail/db/OracleAqFactoryBean.java
@@ -26,6 +26,8 @@ public class OracleAqFactoryBean implements FactoryBean {
 
     @Override
     public Object getObject() throws Exception {
+        // NOTE: if you don't use to session Message Listener for oracle aq, delete me
+        // return AQjmsFactory.getQueueConnectionFactory(defaultDataSource);
         return new ActiveMQConnectionFactory(brokerUrl);
     }
 


### PR DESCRIPTION
- An Oracle Maven repository was added to the pom.xml file in order to effortlessly handle dependencies in the future. In addition, a comment was included in the `OracleAqFactoryBean.java` file to guide developers about the function behavior under certain conditions.